### PR TITLE
Bug Fix: Assert only fixed_atom_mask and fixed_edge_mask can be None in to_xace_mol

### DIFF
--- a/omtra/data/plinder/__init__.py
+++ b/omtra/data/plinder/__init__.py
@@ -112,10 +112,10 @@ class LigandData:
             if k == 'x':
                 xace_dict[k] = xace_dict[k].float()
             else:
-                try:
-                    xace_dict[k] = xace_dict[k].long()
-                except:
-                    print(f"Error converting key {k} to long tensor.")
+                if xace_dict[k] is None:
+                    assert k in ['fixed_atom_mask', 'fixed_edge_mask'], f"{k} is None but not in ['fixed_atom_mask', 'fixed_edge_mask']"
+                    continue
+                xace_dict[k] = xace_dict[k].long()
 
         xace_ligand = MolXACE(**xace_dict)
         if dense:

--- a/omtra/data/plinder/__init__.py
+++ b/omtra/data/plinder/__init__.py
@@ -118,13 +118,13 @@ class LigandData:
             # very hacky bug fix here
             if xace_dict[k] is None and k in ['fixed_atom_mask', 'fixed_edge_mask']:
                 continue
+            elif xace_dict[k] is None and k not in ['fixed_atom_mask', 'fixed_edge_mask']:
+                raise ValueError(f"{k} is None but not in ['fixed_atom_mask', 'fixed_edge_mask']")
+
 
             if k == 'x':
                 xace_dict[k] = xace_dict[k].float()
             else:
-                if xace_dict[k] is None:
-                    assert k in ['fixed_atom_mask', 'fixed_edge_mask'], f"{k} is None but not in ['fixed_atom_mask', 'fixed_edge_mask']"
-                    continue
                 xace_dict[k] = xace_dict[k].long()
 
         xace_ligand = MolXACE(**xace_dict)

--- a/omtra/data/plinder/__init__.py
+++ b/omtra/data/plinder/__init__.py
@@ -112,7 +112,10 @@ class LigandData:
             if k == 'x':
                 xace_dict[k] = xace_dict[k].float()
             else:
-                xace_dict[k] = xace_dict[k].long()
+                try:
+                    xace_dict[k] = xace_dict[k].long()
+                except:
+                    print(f"Error converting key {k} to long tensor.")
 
         xace_ligand = MolXACE(**xace_dict)
         if dense:


### PR DESCRIPTION
File changed: omtra/data/plinder/__init__.py

- Replaced try/except block in `to_xace_mol` with explicit assertion
- If `xace_dict[k]` is None, asserts that `k in ['fixed_atom_mask', 'fixed_edge_mask']`
- Raises AssertionError with message f"{k} is None but not in ['fixed_atom_mask', 'fixed_edge_mask']
- Skips `.long()` conversion for None values
