### PR TITLE
[WIP] exp with SDPA instead of einsum

### DIFF
--- a/omtra/models/transformer.py
+++ b/omtra/models/transformer.py
@@ -1,6 +1,7 @@
 import torch
 import dgl
 import torch.nn as nn
+import torch.nn.functional as F
 from torch.distributions.categorical import Categorical
 import torch_scatter
 from torch.nn import TransformerEncoder, TransformerEncoderLayer
@@ -105,14 +106,21 @@ class AttentionPairBias(nn.Module):
 
         # with torch.autocast("cuda", enabled=False):
         # Compute attention weights
-        attn = torch.einsum("bihd,bjhd->bhij", q.float(), k.float())
-        attn = attn / (self.head_dim**0.5) + bias.float()
-        attn = attn + (1 - mask[:, None, None].float()) * -self.inf
-        # attn = attn + (1 - mask.unsqueeze(1).float()) * -self.inf
-        attn = attn.softmax(dim=-1)
+        # attn = torch.einsum("bihd,bjhd->bhij", q.float(), k.float())
+        # attn = attn / (self.head_dim**0.5) + bias.float()
+        # attn = attn + (1 - mask[:, None, None].float()) * -self.inf
+        # # attn = attn + (1 - mask.unsqueeze(1).float()) * -self.inf
+        # attn = attn.softmax(dim=-1)
 
-        # Compute output
-        o = torch.einsum("bhij,bjhd->bihd", attn, v.float()).to(v.dtype)
+        # # Compute output
+        # o = torch.einsum("bhij,bjhd->bihd", attn, v.float()).to(v.dtype) # has shape (B, N, n_heads, head_dim)
+        
+        combined_attn_mask = bias.float() + (1 - mask[:, None, None, :].float()) * -self.inf
+        
+        o = F.scaled_dot_product_attention(
+            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), # SDPA expects (B, n_heads, N, head_dim)
+            attn_mask=combined_attn_mask,
+        ).transpose(1, 2)
 
         o = o.reshape(B, -1, self.c_s)
         o = self.proj_o(g * o)

--- a/omtra/models/transformer.py
+++ b/omtra/models/transformer.py
@@ -6,6 +6,7 @@ from torch.distributions.categorical import Categorical
 import torch_scatter
 from torch.nn import TransformerEncoder, TransformerEncoderLayer
 from typing import List, Dict, Optional
+from torch.nn.attention import sdpa_kernel, SDPBackend
 from einops.layers.torch import Rearrange
 from einops import rearrange
 from omtra.data.graph.layout import GraphLayout
@@ -115,12 +116,14 @@ class AttentionPairBias(nn.Module):
         # # Compute output
         # o = torch.einsum("bhij,bjhd->bihd", attn, v.float()).to(v.dtype) # has shape (B, N, n_heads, head_dim)
         
-        combined_attn_mask = bias.float() + (1 - mask[:, None, None, :].float()) * -self.inf
-        
-        o = F.scaled_dot_product_attention(
-            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), # SDPA expects (B, n_heads, N, head_dim)
-            attn_mask=combined_attn_mask,
-        ).transpose(1, 2)
+        combined_attn_mask = (bias + (1 - mask[:, None, None, :]) * -self.inf).contiguous()
+
+        # prevent silently falling to MATH backend due to non-contiguous nature of the pairbias 
+        with sdpa_kernel([SDPBackend.CUDNN_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]):
+            o = F.scaled_dot_product_attention(
+                q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+                attn_mask=combined_attn_mask,
+            ).transpose(1, 2)
 
         o = o.reshape(B, -1, self.c_s)
         o = self.proj_o(g * o)

--- a/omtra/models/transformer.py
+++ b/omtra/models/transformer.py
@@ -58,11 +58,10 @@ class AttentionPairBias(nn.Module):
 
         self.compute_pair_bias = compute_pair_bias
         if compute_pair_bias:
-            self.proj_z = nn.Sequential(
+            self.proj_z = torch.compile(nn.Sequential(
                 nn.LayerNorm(c_z),
                 nn.Linear(c_z, num_heads, bias=False),
-                Rearrange("b ... h -> b h ..."),
-            )
+            ))
         else:
             self.proj_z = Rearrange("b ... h -> b h ...")
 
@@ -101,7 +100,7 @@ class AttentionPairBias(nn.Module):
         k = self.proj_k(k_in).view(B, -1, self.num_heads, self.head_dim)
         v = self.proj_v(k_in).view(B, -1, self.num_heads, self.head_dim)
 
-        bias = self.proj_z(z)
+        bias = self.proj_z(z).permute(0, 3, 1, 2)
 
         g = self.proj_g(s).sigmoid()
 


### PR DESCRIPTION
TL;DR: Looks like we can rely on SDPA even with the pair bias track. This will only benefit on longer sequences / more pair-biased attention layers. 

Todos:

- [ ] see if performance improvement is tied to a specific pytorch version
- [ ] see which sequence lengths might benefit from this
- [ ] is self.proj_z(z) anyway dominating the runtime so thsi does not matter?

**More details:** 

- When a dense pair bias is given to `scaled_dot_product_attention` it will fall to Efficient Attention, and it should be competitive with flashattention.

More info about the backends that exist in `F.scaled_dot_product_attention` can be found in the these [slides](https://docs.google.com/presentation/d/17HW7H-5ko03LxiXduLRAonuiEnDiahgOMHvHJbHjKEM/edit?usp=sharing) 

---

I ran two quick experiments to check if the implementations are providing the same answer [wandb report comparing the two runs](https://wandb.ai/koes-group/omtra/reports/Runs-with-SDPA-with-einsum--VmlldzoxNjA1MTg2NQ). I did not see a difference in training speed at this scale though :| 